### PR TITLE
Updating exampel scripts.

### DIFF
--- a/examples/republish.ts
+++ b/examples/republish.ts
@@ -1,19 +1,22 @@
-import { subscribe, publish } from '../pubsub';
+import { subscribe, publish, natsConnect } from '../pubsub';
 import { Message } from '../pubsub';
 import {NatsConfig} from "../pubsub/types";
 
-const natsWsUrl = 'wss://url.com:443';
-const userCredsJWT = 'USER_JWT';
-const userCredsSeed = 'CREDS_SEED';
-const exampleSubscribeSubject = 'example.sub.subject';
-const examplePublishSubject = 'example.pub.subject';
+const natsWsUrl = "wss://127.0.0.1";
+const subscriberUserCredsJWT = 'USER_JWT';
+const subscriberUserCredsSeed = 'EXAMPLE_ACCESS_TOKEN';
+const publisherUserCredsJWT = 'USER_JWT';
+const publisherUserCredsSeed = 'EXAMPLE_ACCESS_TOKEN';
+const exampleSubscribeSubject = 'synternet.example.subject';
+const examplePublishSubject = 'publisher.example.subject';
 
-var config: NatsConfig;
+var subscriberConfig: NatsConfig;
+var publisherConfig: NatsConfig;
 
 async function republishData(message: Message) {
-    console.log('Received message on', exampleSubscribeSubject, 'subject');
-    publish(examplePublishSubject, message.data, config);
-    console.log('Published message on', examplePublishSubject, 'subject');
+    console.log('Received message on', exampleSubscribeSubject, message.data);
+    publish(examplePublishSubject, message.data, publisherConfig);
+    console.log('Published message on', examplePublishSubject, message.data);
 }
 
 const onMessages = async (messages: Message[]) => {
@@ -27,16 +30,19 @@ const onError = (text: string, error: Error) => {
 };
 
 async function main() {
-    config = { url: natsWsUrl }
+    subscriberConfig = { url: natsWsUrl }
     await subscribe({
         onMessages,
         onError,
-        jwt: userCredsJWT,
-        nkey: userCredsSeed,
-        config: config,
+        jwt: subscriberUserCredsJWT,
+        nkey: subscriberUserCredsSeed,
+        config: subscriberConfig,
         subject: exampleSubscribeSubject
     });
-    console.log('Connected to NATS server.');
+    console.log('Subscriber connected to NATS server.');
+    const publishConnection = await natsConnect({ url: natsWsUrl }, publisherUserCredsJWT, publisherUserCredsSeed);
+    publisherConfig = { url: natsWsUrl, connection: publishConnection }
+    console.log('Publisher connected to NATS server.');
 }
 
 main();

--- a/examples/subscribe_with_seed.ts
+++ b/examples/subscribe_with_seed.ts
@@ -3,14 +3,14 @@ import { Message } from '../pubsub';
 import {NatsConfig} from "../pubsub/types";
 import {createAppJwt} from "../pubsub/userJwt";
 
-const natsWsUrl = 'wss://url.com:443';
-const accessToken = 'SAAGNJOZTRPYYXG2NJX3ZNGXYUSDYX2BWO447W3SHG6XQ7U66RWHQ3JUXM';
-const exampleSubscribeSubject = 'example.sub.subject';
+const natsWsUrl = "wss://127.0.0.1";
+const accessToken = 'EXAMPLE_ACCESS_TOKEN';
+const exampleSubscribeSubject = "publisher.example.subject";
 
 var config: NatsConfig;
 
 async function printData(message: Message) {
-    console.log('Received message on', exampleSubscribeSubject, 'subject');
+    console.log('Received message:', message.data);
 }
 
 const onMessages = async (messages: Message[]) => {


### PR DESCRIPTION



## Description
Updated both given example scripts to the latest scenarios according to Synternet Portal.

## Proposed Changes
List the specific changes or additions made in this PR.

- 'subscribe_with_seed.ts':
   1. 'accessToken' variable changed from specific nkeys to generic one. (Unified to other Synternet pubsubs)
   2. Instead of generic print - changed so printData() function would print actual subject messages (data) -> console.log('Received message:', message.data);
- 'republish.ts': complete rework of a script. Previously used deprecated scenario when one JWT is used for publishing and subscribing. According to Synternet Portal publish action must be performed by the publisher and subscribing by the subscriber profile. Now to republish - you will need separate profiles and separate JWT's/nkeys. That required for 'natsConnect' import and NatsConfig split.


## Additional Info
Example update so that other users could try it out/re-use it.

## Checklist
- [X] I have tested these changes locally
- [X] I have reviewed the code for any potential issues
- [X] I have documented any necessary changes

